### PR TITLE
[detach_away] Behavioral change: set away on last client disconnect, not first client

### DIFF
--- a/python/detach_away.py
+++ b/python/detach_away.py
@@ -24,7 +24,7 @@ else:
 
 SCRIPT_NAME = 'detach_away'
 SCRIPT_AUTHOR = 'p3lim'
-SCRIPT_VERSION = '0.1.2'
+SCRIPT_VERSION = '0.1.3'
 SCRIPT_LICENSE = 'MIT'
 SCRIPT_DESC = 'Automatically sets away message based on number of relays connected'
 
@@ -66,7 +66,7 @@ def relay_disconnected(data, signal, signal_data):
     if DEBUG():
         weechat.prnt('', 'DETACH_AWAY: last #relays: ' + str(num_relays))
 
-    if int(num_relays) > 0:
+    if int(num_relays) == 1:
         set_away(True)
 
     num_relays = weechat.info_get('relay_client_count', 'connected')

--- a/python/detach_away.py
+++ b/python/detach_away.py
@@ -7,6 +7,7 @@
 # Changelog:
 # Ver: 0.1.1 Python3 support by Antonin Skala skala.antonin@gmail.com 3.2019
 # Ver: 0.1.2 Support Python 2 and 3 by Antonin Skala skala.antonin@gmail.com 3.2019
+# Ver: 0.1.3 Set away after last relay client disconnects by Joris Talma joris@talma.nl
 
 try:
     import weechat


### PR DESCRIPTION
In version 0.1.2, the script is setting away as soon as the *first* relay client disconnects.
This merge changes this functionality: it will set away after the *last* relay disconnects,
just like the irssi awayproxy script with an away_level of 0 (default value: away when no clients are connected to the proxy module).